### PR TITLE
docs: fix simple typo, pelease -> please

### DIFF
--- a/hookzz/src/zzdeps/darwin/memory-utils-darwin.c
+++ b/hookzz/src/zzdeps/darwin/memory-utils-darwin.c
@@ -466,7 +466,7 @@ zbool zz_vm_patch_code_via_task(task_t task, const zaddr address, const zpointer
     }
 
     /*
-      another method, pelease read `REF`;
+      another method, please read `REF`;
 
      */
     // zpointer code_mmap = mmap(NULL, range_size, PROT_READ | PROT_WRITE,

--- a/hookzz/src/zzdeps/posix/memory-utils-posix.c
+++ b/hookzz/src/zzdeps/posix/memory-utils-posix.c
@@ -219,7 +219,7 @@ zbool zz_posix_vm_patch_code(const zaddr address, const zpointer codedata, zuint
     page_offset = address - start_page_addr;
     range_size = (end_page_addr + page_size) - start_page_addr;
 
-    //  another method, pelease read `REF`;
+    //  another method, please read `REF`;
 
     // zpointer code_mmap = mmap(NULL, range_size, PROT_READ | PROT_WRITE,
     //                           MAP_ANON | MAP_SHARED, -1, 0);


### PR DESCRIPTION
There is a small typo in hookzz/src/zzdeps/darwin/memory-utils-darwin.c, hookzz/src/zzdeps/posix/memory-utils-posix.c.

Should read `please` rather than `pelease`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md