### PR TITLE
fix: simplify demo section

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,22 +257,15 @@ sh go.sh /path/to/appletracedata
 
 ## 📊 Demo
 
-<div align="center">
-
 ### Interactive Demo
 
-<a href="sampledata/trace.html">
-  <img src="image/appletrace-small.png" alt="AppleTrace Demo" width="80%"/>
-</a>
+Explore a pre-recorded trace directly in Chrome:
 
-<p>
-  <em>Click the image above to explore an interactive trace demo in Chrome</em>
-</p>
+- 📂 **[Interactive Trace Demo](sampledata/trace.html)** - Open in Chrome to see AppleTrace in action
 
-### Pre-recorded Traces
-- 📂 [Interactive HTML Demo](sampledata/trace.html) - Open in Chrome for full interactivity
+![Demo Preview](image/appletrace-small.png)
 
-</div>
+*The trace visualization shows method execution timeline and call relationships.*
 
 ---
 


### PR DESCRIPTION
## Summary

This PR simplifies the Demo section by removing the large clickable image that was visually unappealing.

### Changes

- ✅ Removed the large 80% width clickable image from the Demo section
- ✅ Added a static preview image instead (smaller, non-clickable)
- ✅ Kept the trace.html link as a simple text link
- ✅ Improved formatting with better visual hierarchy
- ✅ Added descriptive caption explaining the image

### Before

- Large clickable image (80% width)
- Required user to click to see demo
- Imbalanced visual weight in the section

### After

- Static preview image (smaller, informational)
- Simple text link to the demo
- Cleaner, more professional appearance

---

**Related:** PR #9, #10
**Target Branch:** `master`
**Reviewers:** @everettjf