### PR TITLE
docs: GitHub Pages tutorial site (Tutorial/) — EN + 中文

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,38 @@
+name: Deploy Tutorial to GitHub Pages
+
+# Publishes the static site in Tutorial/ to GitHub Pages.
+# One-time setup: repo Settings ▸ Pages ▸ Build and deployment ▸ Source =
+# "GitHub Actions".
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'Tutorial/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress one.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: Tutorial
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 **A lightweight, embeddable Objective-C tracer that produces shareable [Perfetto](https://ui.perfetto.dev) traces**
 
+📖 **[Read the full Tutorial &amp; Usage Guide →](https://everettjf.github.io/AppleTrace/)**
+
 [English](README.md) | [中文](README_CN.md)
 
 </div>

--- a/README_CN.md
+++ b/README_CN.md
@@ -11,6 +11,8 @@
 
 **轻量、可内嵌的 Objective-C 追踪器，产物可直接拖入 [Perfetto](https://ui.perfetto.dev) 分享**
 
+📖 **[阅读完整教程与使用指南 →](https://everettjf.github.io/AppleTrace/zh.html)**
+
 [English](README.md) | [中文](README_CN.md)
 
 </div>

--- a/Tutorial/README.md
+++ b/Tutorial/README.md
@@ -1,0 +1,21 @@
+# AppleTrace Tutorial site
+
+A static, no-build GitHub Pages site — the comprehensive usage guide for
+AppleTrace (English primary, Chinese secondary).
+
+- `index.html` — English guide
+- `zh.html` — 中文指南
+- `styles.css`, `app.js` — shared styling and progressive-enhancement JS
+- `.nojekyll` — serve files as-is (no Jekyll processing)
+
+## Preview locally
+
+```bash
+cd Tutorial && python3 -m http.server 8000   # then open http://localhost:8000
+```
+
+## Publishing
+
+Deployed by `.github/workflows/pages.yml` on every push to `master` that
+touches `Tutorial/`. One-time setup: repo **Settings ▸ Pages ▸ Source =
+GitHub Actions**.

--- a/Tutorial/app.js
+++ b/Tutorial/app.js
@@ -1,0 +1,56 @@
+// AppleTrace tutorial — progressive enhancement only; the page works without JS.
+(function () {
+    'use strict';
+
+    // Copy buttons on code blocks.
+    document.querySelectorAll('.code').forEach(function (block) {
+        var head = block.querySelector('.code-head');
+        if (!head) return;
+        var btn = head.querySelector('.copy');
+        if (!btn) return;
+        btn.addEventListener('click', function () {
+            var code = block.querySelector('pre');
+            if (!code) return;
+            navigator.clipboard.writeText(code.innerText).then(function () {
+                var prev = btn.textContent;
+                btn.textContent = 'copied';
+                setTimeout(function () { btn.textContent = prev; }, 1400);
+            });
+        });
+    });
+
+    // Mobile sidebar toggle.
+    var sidebar = document.querySelector('.sidebar');
+    var menuBtn = document.querySelector('.menu-btn');
+    var scrim = document.querySelector('.scrim');
+    function close() { sidebar && sidebar.classList.remove('open'); scrim && scrim.classList.remove('show'); }
+    if (menuBtn && sidebar) {
+        menuBtn.addEventListener('click', function () {
+            sidebar.classList.toggle('open');
+            scrim && scrim.classList.toggle('show');
+        });
+    }
+    if (scrim) scrim.addEventListener('click', close);
+    sidebar && sidebar.querySelectorAll('a').forEach(function (a) { a.addEventListener('click', close); });
+
+    // Scroll-spy: highlight the sidebar link for the section in view.
+    var links = Array.prototype.slice.call(document.querySelectorAll('.sidebar a[href^="#"]'));
+    var map = {};
+    links.forEach(function (a) {
+        var id = a.getAttribute('href').slice(1);
+        var sec = document.getElementById(id);
+        if (sec) map[id] = a;
+    });
+    var sections = Object.keys(map).map(function (id) { return document.getElementById(id); });
+    if ('IntersectionObserver' in window && sections.length) {
+        var current = null;
+        var obs = new IntersectionObserver(function (entries) {
+            entries.forEach(function (e) {
+                if (e.isIntersecting) current = e.target.id;
+            });
+            links.forEach(function (a) { a.classList.remove('active'); });
+            if (current && map[current]) map[current].classList.add('active');
+        }, { rootMargin: '-20% 0px -70% 0px', threshold: 0 });
+        sections.forEach(function (s) { obs.observe(s); });
+    }
+})();

--- a/Tutorial/index.html
+++ b/Tutorial/index.html
@@ -1,0 +1,349 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>AppleTrace — Tutorial &amp; Usage Guide</title>
+<meta name="description" content="A complete guide to AppleTrace: instrument Objective-C, C/C++, and Swift, then explore the timeline in Perfetto.">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+<header class="topbar">
+    <a class="brand" href="index.html"><span class="dot"></span>AppleTrace</a>
+    <button class="menu-btn" aria-label="Menu">☰</button>
+    <div class="spacer"></div>
+    <nav>
+        <a class="hide-sm" href="#quick-start">Quick Start</a>
+        <a class="hide-sm" href="https://github.com/everettjf/AppleTrace" target="_blank" rel="noopener">GitHub ↗</a>
+        <span class="lang-toggle"><a class="active" href="index.html">EN</a><a href="zh.html">中文</a></span>
+    </nav>
+</header>
+
+<div class="scrim"></div>
+
+<div class="shell">
+    <aside class="sidebar">
+        <h4>Get Started</h4>
+        <a href="#introduction">Introduction</a>
+        <a href="#quick-start">Quick Start</a>
+        <a href="#installation">Installation</a>
+        <h4>Tutorials</h4>
+        <a href="#manual">Manual Instrumentation</a>
+        <a href="#swift">Tracing Swift</a>
+        <a href="#objc-hook">objc_msgSend Hook</a>
+        <a href="#events">Event Types</a>
+        <h4>Workflow</h4>
+        <a href="#visualize">Visualize in Perfetto</a>
+        <a href="#demos">Demo Apps</a>
+        <h4>Reference</h4>
+        <a href="#env">Environment Variables</a>
+        <a href="#platforms">Platform Support</a>
+        <a href="#faq">FAQ &amp; Troubleshooting</a>
+    </aside>
+
+    <main>
+        <div class="content">
+
+        <!-- HERO -->
+        <div class="hero">
+            <div class="eyebrow">iOS / macOS Tracing → Perfetto</div>
+            <h1>The <span class="apple">AppleTrace</span> field guide.</h1>
+            <p class="lede">A lightweight, embeddable tracer that records your app's execution timeline — manual sections, Swift macros, or every <code>objc_msgSend</code> — and renders it in <a href="https://ui.perfetto.dev" target="_blank" rel="noopener">Perfetto</a>, right in the browser.</p>
+            <div class="hero-actions">
+                <a class="btn btn-primary" href="#quick-start">Start in 5 minutes →</a>
+                <a class="btn btn-ghost" href="https://github.com/everettjf/AppleTrace" target="_blank" rel="noopener">View on GitHub</a>
+            </div>
+
+            <div class="timeline" aria-hidden="true">
+                <div class="tl-row"><span class="tl-label">Main Thread</span><span class="tl-track">
+                    <span class="tl-slice" style="left:0;width:24%;background:var(--accent);animation-delay:.05s"></span>
+                    <span class="tl-slice" style="left:26%;width:40%;background:var(--accent);animation-delay:.15s"></span>
+                    <span class="tl-slice" style="left:68%;width:30%;background:var(--accent);animation-delay:.25s"></span>
+                </span></div>
+                <div class="tl-row"><span class="tl-label">RenderLoop</span><span class="tl-track">
+                    <span class="tl-slice" style="left:8%;width:14%;background:var(--violet);animation-delay:.3s"></span>
+                    <span class="tl-slice" style="left:24%;width:14%;background:var(--violet);animation-delay:.4s"></span>
+                    <span class="tl-slice" style="left:40%;width:14%;background:var(--violet);animation-delay:.5s"></span>
+                    <span class="tl-slice" style="left:56%;width:14%;background:var(--violet);animation-delay:.6s"></span>
+                </span></div>
+                <div class="tl-row"><span class="tl-label">NetworkClient</span><span class="tl-track">
+                    <span class="tl-slice" style="left:30%;width:52%;background:var(--coral);animation-delay:.45s"></span>
+                </span></div>
+                <div class="tl-row"><span class="tl-label">FPS</span><span class="tl-track">
+                    <span class="tl-slice" style="left:0;width:100%;background:linear-gradient(90deg,var(--amber),transparent);height:8px;top:4px;animation-delay:.7s"></span>
+                </span></div>
+            </div>
+        </div>
+
+        <!-- INTRODUCTION -->
+        <section id="introduction">
+            <h2>Introduction</h2>
+            <p>AppleTrace instruments your app — by adding markers, annotating Swift functions, or hooking message sends — and writes a timeline of events into sandbox <em>trace fragments</em>. A small Python pipeline merges those fragments into a single <code>trace.json</code> that you open directly in Perfetto to explore the call timeline, durations, threads, and counters.</p>
+            <p>There are three ways to produce events. Pick whichever fits — they all land in the same trace:</p>
+            <div class="grid2">
+                <div class="card">
+                    <span class="tag everywhere">all platforms</span>
+                    <h3>Manual sections</h3>
+                    <p>Wrap code in <code>APTBeginSection</code>/<code>APTEndSection</code> (or the Swift macros). The lowest-risk baseline; you control exactly what is timed.</p>
+                </div>
+                <div class="card">
+                    <span class="tag arm">arm64</span>
+                    <h3>objc_msgSend hook</h3>
+                    <p>Automatically trace every Objective-C message send via a fishhook-style symbol rebind. Zero code changes, Objective-C only.</p>
+                </div>
+                <div class="card">
+                    <span class="tag sim">Simulator / macOS</span>
+                    <h3>Swift auto-hook</h3>
+                    <p>The optional <code>AppleTraceAuto</code> product bridges SwiftTrace to trace Swift class hierarchies with no annotations.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- QUICK START -->
+        <section id="quick-start">
+            <h2>Quick Start</h2>
+            <p>The fastest path to a trace is the bundled demo app — no instrumentation to write.</p>
+            <ol class="steps">
+                <li><strong>Clone &amp; open a demo.</strong>
+                    <div class="code"><div class="code-head"><span class="lang">bash</span><button class="copy">copy</button></div><pre><code>git clone https://github.com/everettjf/AppleTrace.git
+cd AppleTrace
+open sample/AppleTraceSwiftDemo/AppleTraceSwiftDemo.xcodeproj</code></pre></div>
+                </li>
+                <li><strong>Run it</strong> on a Simulator (or device) and tap <strong>Generate Trace</strong>. The app runs a multi-threaded workload and prints the on-disk <em>trace directory</em>.</li>
+                <li><strong>Merge the fragments</strong> into a single trace on your Mac:
+                    <div class="code"><div class="code-head"><span class="lang">bash</span><button class="copy">copy</button></div><pre><code>python3 merge.py -d "&lt;trace directory shown in the app&gt;"
+# → writes trace.json next to the fragments</code></pre></div>
+                </li>
+                <li><strong>Open it in Perfetto.</strong> Go to <a href="https://ui.perfetto.dev" target="_blank" rel="noopener">ui.perfetto.dev</a> and drag in <code>trace.json</code>. That's it.</li>
+            </ol>
+            <div class="callout tip"><span class="ic">💡</span><p>In a hurry? <code>sh go.sh "&lt;trace directory&gt;"</code> merges <em>and</em> opens Perfetto in one step.</p></div>
+        </section>
+
+        <!-- INSTALLATION -->
+        <section id="installation">
+            <h2>Installation</h2>
+            <h3>Requirements</h3>
+            <ul>
+                <li>Xcode, Python 3, and a browser (Perfetto runs at <a href="https://ui.perfetto.dev" target="_blank" rel="noopener">ui.perfetto.dev</a>).</li>
+                <li><code>ldid</code> only if you re-sign loader builds; <code>pytest</code> only for the test suite.</li>
+            </ul>
+
+            <h3>Swift Package (for Swift, and the cleanest path for new projects)</h3>
+            <p>Add the package and depend on the <code>AppleTrace</code> product (and optionally <code>AppleTraceAuto</code>):</p>
+            <div class="code"><div class="code-head"><span class="lang">swift — Package.swift</span><button class="copy">copy</button></div><pre><code>dependencies: [
+    .package(url: "https://github.com/everettjf/AppleTrace.git", branch: "master"),
+],
+targets: [
+    .target(name: "MyApp", dependencies: [
+        .product(name: "AppleTrace", package: "AppleTrace"),
+        // optional, Simulator/macOS only:
+        .product(name: "AppleTraceAuto", package: "AppleTrace"),
+    ]),
+]</code></pre></div>
+
+            <h3>Framework embedding (Objective-C / C / C++)</h3>
+            <p>Open <code>appletrace/appletrace.xcodeproj</code>, build the framework, and embed <code>appletrace.framework</code> into your target. See <code>sample/ManualSectionDemo</code> for a working setup.</p>
+        </section>
+
+        <!-- MANUAL -->
+        <section id="manual">
+            <h2>Tutorial · Manual Instrumentation</h2>
+            <p>Manual sections are the recommended baseline — they work on every iOS/macOS version and produce clean, descriptively-named slices.</p>
+
+            <h3>Objective-C</h3>
+            <div class="code"><div class="code-head"><span class="lang">objective-c</span><button class="copy">copy</button></div><pre><code>#import &lt;appletrace/appletrace.h&gt;
+
+- (void)viewDidLoad {
+    APTBegin;                       // auto-named "[ClassName viewDidLoad]"
+    [super viewDidLoad];
+    APTEnd;
+}
+
+- (void)loadFeed {
+    APTBeginSection("network");     // explicit section name
+    // ... work ...
+    APTEndSection("network");
+}</code></pre></div>
+            <p><code>APTBegin</code> / <code>APTEnd</code> name the section after the enclosing class and selector. Use <code>APTBeginSection</code> / <code>APTEndSection</code> when you want a custom name. Pairs nest on the same thread (LIFO).</p>
+
+            <h3>C / C++</h3>
+            <div class="code"><div class="code-head"><span class="lang">cpp</span><button class="copy">copy</button></div><pre><code>#include &lt;appletrace/appletrace.h&gt;
+
+void process() {
+    APTBeginSection("process");
+    // ... work ...
+    APTEndSection("process");
+}
+
+void safer() {
+    APTScopeSection("decode");      // RAII: ends automatically at scope exit
+    // ... work ...
+}</code></pre></div>
+            <div class="callout warn"><span class="ic">⚠️</span><p>Events are buffered per thread and flushed on a size threshold, on <code>APTFlush()</code>, or at thread exit. <strong>Call <code>APTFlush()</code></strong> (e.g. when backgrounding) before pulling the trace, or short-lived runs may look empty.</p></div>
+        </section>
+
+        <!-- SWIFT -->
+        <section id="swift">
+            <h2>Tutorial · Tracing Swift</h2>
+            <p>The <code>objc_msgSend</code> hook can't see Swift's static / vtable / witness dispatch, so Swift is traced at the <strong>source level</strong>. After adding the Swift package, <code>import AppleTrace</code>.</p>
+
+            <h3>Scoped spans &amp; macros</h3>
+            <div class="code"><div class="code-head"><span class="lang">swift</span><button class="copy">copy</button></div><pre><code>import AppleTrace
+
+// Scoped span — closes even on throw / early return:
+withSpan("loadFeed") { try? loadFeed() }
+
+// Annotate a function. The section is named after #function, so it works
+// for final classes, structs, and protocol methods alike — the begin/end
+// is inserted into the body at compile time, sidestepping dispatch entirely.
+@Traced
+func decodeImage() { /* ... */ }
+
+// @TraceAll stamps @Traced onto every method with a body:
+@TraceAll
+final class FeedViewModel {
+    func reload() { /* traced */ }
+    func render() { /* traced */ }
+}
+
+APTFlush()   // or AppleTrace.flush()</code></pre></div>
+
+            <h3>Zero-annotation auto-tracing</h3>
+            <p>The optional <code>AppleTraceAuto</code> product bridges <a href="https://github.com/johnno1962/SwiftTrace" target="_blank" rel="noopener">SwiftTrace</a> to hook a class hierarchy without annotations:</p>
+            <div class="code"><div class="code-head"><span class="lang">swift</span><button class="copy">copy</button></div><pre><code>import AppleTraceAuto
+
+#if targetEnvironment(simulator)
+AppleTraceAuto.trace(aClass: FeedViewModel.self)   // entry/exit → AppleTrace
+#endif</code></pre></div>
+            <div class="callout danger"><span class="ic">🚫</span><p><strong><code>AppleTraceAuto</code> is Simulator / macOS only.</strong> SwiftTrace patches pointer-authenticated vtable slots, which is unsafe on real devices — always gate it with <code>#if targetEnvironment(simulator)</code>. It also can't see <code>final</code> / statically-dispatched methods. The macros have neither limitation and are the on-device path.</p></div>
+        </section>
+
+        <!-- OBJC HOOK -->
+        <section id="objc-hook">
+            <h2>Tutorial · Automatic objc_msgSend Hook</h2>
+            <p>For Objective-C apps you can trace <em>every</em> message send with no manual markers. The hook is an arm64 fishhook-style symbol rebind; install it once after launch:</p>
+            <div class="code"><div class="code-head"><span class="lang">objective-c</span><button class="copy">copy</button></div><pre><code>// e.g. early in application:didFinishLaunchingWithOptions:
+if (APTInstallObjcMsgSendHook()) {
+    NSLog(@"AppleTrace: objc_msgSend hook installed");
+}</code></pre></div>
+            <p>Every traced send becomes a <code>[Class]selector</code> begin/end pair. See <code>sample/TraceAllMsgDemo</code> for a full setup, including the validated handling of floating-point arguments, struct returns, and <code>super</code> dispatch.</p>
+            <div class="callout warn"><span class="ic">⚠️</span><p><strong>arm64 only.</strong> The hook hard-errors on arm64e (its callers reach <code>objc_msgSend</code> through authenticated GOT entries). Build a plain arm64 slice.</p></div>
+        </section>
+
+        <!-- EVENTS -->
+        <section id="events">
+            <h2>Tutorial · Event Types</h2>
+            <p>Beyond sections, AppleTrace records the event kinds Perfetto knows how to draw:</p>
+            <div class="code"><div class="code-head"><span class="lang">objective-c</span><button class="copy">copy</button></div><pre><code>// Instantaneous marker on the current thread's timeline
+APTInstant("cache_miss");
+
+// A value plotted over time → a counter graph track (memory, FPS, queue depth…)
+APTCounter("resident_mb", 142.5);
+APTCounter("fps", 60);
+
+// Work that flows across threads / queues, matched by (name, id) → async arc
+uint64_t reqID = 42;
+APTAsyncBegin("image_load", reqID);
+dispatch_async(queue, ^{
+    APTAsyncEnd("image_load", reqID);
+});</code></pre></div>
+            <table>
+                <tr><th>Event</th><th>API</th><th>Perfetto rendering</th></tr>
+                <tr><td>Section</td><td><code>APTBeginSection</code> / <code>APTEndSection</code></td><td>Nested slices on a thread track</td></tr>
+                <tr><td>Instant</td><td><code>APTInstant</code></td><td>A marker at a point in time</td></tr>
+                <tr><td>Counter</td><td><code>APTCounter</code></td><td>A graph track</td></tr>
+                <tr><td>Async</td><td><code>APTAsyncBegin</code> / <code>APTAsyncEnd</code></td><td>Arcs that can cross threads</td></tr>
+            </table>
+            <p>The Swift wrappers mirror these: <code>traceInstant</code>, <code>traceCounter</code>, <code>asyncBegin</code>, <code>asyncEnd</code>.</p>
+        </section>
+
+        <!-- VISUALIZE -->
+        <section id="visualize">
+            <h2>Visualize in Perfetto</h2>
+            <h3>1 · Pull the trace fragments</h3>
+            <p>Fragments are written to <code>&lt;app sandbox&gt;/Library/appletracedata</code>.</p>
+            <ul>
+                <li><strong>Simulator:</strong> the folder is already on your Mac; the demo app prints the path.</li>
+                <li><strong>Device:</strong> Xcode ▸ <em>Window ▸ Devices and Simulators ▸ Download Container</em>, or <code>xcrun devicectl device copy from … --domain-type appDataContainer --source Library/appletracedata --destination ./trace</code>.</li>
+            </ul>
+            <h3>2 · Merge</h3>
+            <div class="code"><div class="code-head"><span class="lang">bash</span><button class="copy">copy</button></div><pre><code>python3 merge.py -d /path/to/appletracedata     # → trace.json
+# or the unified CLI:
+python3 scripts/appletrace_cli.py open /path/to/appletracedata
+# or merge AND open Perfetto:
+sh go.sh /path/to/appletracedata</code></pre></div>
+            <h3>3 · Explore</h3>
+            <p>Drag <code>trace.json</code> into <a href="https://ui.perfetto.dev" target="_blank" rel="noopener">ui.perfetto.dev</a>. Use <kbd>W</kbd>/<kbd>S</kbd> to zoom, <kbd>A</kbd>/<kbd>D</kbd> to pan, and the search box to jump to a slice.</p>
+            <h3>Binary fragments (optional, smaller &amp; faster)</h3>
+            <p>Set <code>APPLETRACE_BINARY=1</code> to write a compact binary fragment format instead of text. <code>merge.py</code> decodes both transparently — no workflow change.</p>
+        </section>
+
+        <!-- DEMOS -->
+        <section id="demos">
+            <h2>Demo Apps</h2>
+            <p>Three runnable samples, each a complete reference:</p>
+            <table>
+                <tr><th>Sample</th><th>Language</th><th>Demonstrates</th></tr>
+                <tr><td><code>sample/ManualSectionDemo</code></td><td>Objective-C</td><td>Manual sections, counters, async, threads</td></tr>
+                <tr><td><code>sample/AppleTraceSwiftDemo</code></td><td>Swift</td><td><code>@Traced</code>/<code>@TraceAll</code>/<code>withSpan</code> + the <code>AppleTraceAuto</code> hook</td></tr>
+                <tr><td><code>sample/TraceAllMsgDemo</code></td><td>Objective-C</td><td>Automatic <code>objc_msgSend</code> hook</td></tr>
+            </table>
+            <p>Each guided app has a <strong>Generate Trace</strong> button, shows the trace directory, and prints the exact merge/Perfetto commands. The Swift demo consumes the local package, so open it from the repo so Xcode resolves the products automatically.</p>
+        </section>
+
+        <!-- ENV -->
+        <section id="env">
+            <h2>Environment Variables</h2>
+            <table>
+                <tr><th>Variable</th><th>Default</th><th>Effect</th></tr>
+                <tr><td><code>APPLETRACE_ENABLED</code></td><td><code>true</code></td><td>Master on/off switch for recording.</td></tr>
+                <tr><td><code>APPLETRACE_BINARY</code></td><td><code>false</code></td><td>Write compact binary fragments instead of text.</td></tr>
+                <tr><td><code>APPLETRACE_DATA_DIR</code></td><td><em>sandbox</em></td><td>Override where fragments are written.</td></tr>
+                <tr><td><code>APPLETRACE_BLOCK_SIZE_MB</code></td><td><code>16</code></td><td>Per-fragment mmap block size (1–256 MB).</td></tr>
+                <tr><td><code>APPLETRACE_KEEP_EXISTING</code></td><td><code>false</code></td><td>Keep prior trace dirs instead of replacing them.</td></tr>
+            </table>
+            <p>Runtime controls are also available in code: <code>APTSetEnabled(BOOL)</code>, <code>APTIsEnabled()</code>, <code>APTGetTraceDirectory()</code>, <code>APTFlush()</code>, <code>APTSyncWait()</code>.</p>
+        </section>
+
+        <!-- PLATFORMS -->
+        <section id="platforms">
+            <h2>Platform Support</h2>
+            <table>
+                <tr><th>Mode</th><th>Where it works</th></tr>
+                <tr><td>Manual sections &amp; events</td><td>Every iOS/macOS version, all languages</td></tr>
+                <tr><td>Swift macros (<code>@Traced</code>/<code>@TraceAll</code>/<code>withSpan</code>)</td><td>Simulator <strong>and device</strong></td></tr>
+                <tr><td><code>objc_msgSend</code> hook</td><td>arm64 (not arm64e)</td></tr>
+                <tr><td><code>AppleTraceAuto</code> (SwiftTrace)</td><td>Simulator / macOS only</td></tr>
+            </table>
+            <h3>Why Swift needs source-level tracing</h3>
+            <p>Swift avoids message dispatch for speed: <code>struct</code>/<code>final</code> methods and whole-module-optimized calls are <em>statically</em> dispatched; class methods use a <em>vtable</em>; protocol methods use a <em>witness table</em>. None go through <code>objc_msgSend</code>, so only the thin <code>@objc dynamic</code> surface is visible to the auto-hook. The macros instrument the source directly, which is why they cover all four dispatch kinds.</p>
+        </section>
+
+        <!-- FAQ -->
+        <section id="faq">
+            <h2>FAQ &amp; Troubleshooting</h2>
+            <h4>My trace is empty / only has metadata</h4>
+            <p>The writer batches per thread. Call <code>APTFlush()</code> before reading the trace (e.g. on backgrounding, or at the end of your scenario). The demo apps flush for you.</p>
+            <h4>Build fails: <code>SDK does not contain 'libarclite'</code></h4>
+            <p>An old deployment target. Set <code>IPHONEOS_DEPLOYMENT_TARGET</code> to 12.0 or later — recent Xcode dropped the ARC compatibility library for pre-12 targets.</p>
+            <h4>The Swift app crashes at launch with <code>Library not loaded: @rpath/SwiftTrace.framework</code></h4>
+            <p>The app target needs <code>LD_RUNPATH_SEARCH_PATHS = @executable_path/Frameworks</code> so dyld can find the embedded dynamic framework on device.</p>
+            <h4><code>AppleTraceAuto</code> traces nothing for some methods</h4>
+            <p>SwiftTrace can't hook <code>final</code> or statically-dispatched methods, and it's Simulator/macOS only. Use the <code>@Traced</code>/<code>@TraceAll</code> macros for those.</p>
+            <h4>Command-line <code>xcodebuild</code> can't find SwiftSyntax for the macro plugin</h4>
+            <p>Drop the <code>-sdk iphonesimulator</code> flag and pass only <code>-destination</code>; <code>-sdk</code> forces the host macro plugin onto the wrong SDK.</p>
+        </section>
+
+        </div><!-- /content -->
+        <footer>
+            <p>AppleTrace is MIT-licensed. Visualization is <a href="https://ui.perfetto.dev" target="_blank" rel="noopener">Perfetto</a>-only. ·
+            <a href="https://github.com/everettjf/AppleTrace" target="_blank" rel="noopener">github.com/everettjf/AppleTrace</a> ·
+            <a href="zh.html">中文版</a></p>
+        </footer>
+    </main>
+</div>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/Tutorial/styles.css
+++ b/Tutorial/styles.css
@@ -1,0 +1,191 @@
+/* ===========================================================================
+   AppleTrace Tutorial — trace-viewer aesthetic
+   Dark, precise, developer-console feel echoing a Perfetto timeline.
+   =========================================================================== */
+
+@import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400..800&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap');
+
+:root {
+    --bg: #0c1014;
+    --bg-elev: #131a21;
+    --bg-elev-2: #1a232c;
+    --bg-code: #0f161d;
+    --border: #243039;
+    --border-soft: #1b242c;
+    --text: #e7eef4;
+    --text-dim: #98a6b3;
+    --text-faint: #65727d;
+    --accent: #4ecdc4;
+    --accent-deep: #2aa39a;
+    --coral: #ff6b6b;
+    --amber: #ffd166;
+    --violet: #b08cff;
+    --maxw: 1320px;
+    --sidebar-w: 264px;
+    --header-h: 60px;
+    --radius: 12px;
+    --mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+    --sans: 'IBM Plex Sans', system-ui, sans-serif;
+    --display: 'Bricolage Grotesque', var(--sans);
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { scroll-behavior: smooth; scroll-padding-top: calc(var(--header-h) + 20px); }
+
+body {
+    font-family: var(--sans);
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.65;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    /* faint trace-lane grid texture */
+    background-image:
+        radial-gradient(900px 500px at 85% -8%, rgba(78, 205, 196, 0.10), transparent 60%),
+        radial-gradient(700px 500px at -5% 0%, rgba(176, 140, 255, 0.07), transparent 55%);
+    background-attachment: fixed;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* --------------------------------------------------------------- header --- */
+header.topbar {
+    position: fixed; inset: 0 0 auto 0; height: var(--header-h); z-index: 100;
+    display: flex; align-items: center; gap: 16px;
+    padding: 0 22px;
+    background: rgba(12, 16, 20, 0.82);
+    backdrop-filter: blur(14px);
+    border-bottom: 1px solid var(--border);
+}
+.brand { display: flex; align-items: center; gap: 10px; font-family: var(--display); font-weight: 700; font-size: 18px; letter-spacing: -0.02em; color: var(--text); }
+.brand .dot { width: 11px; height: 11px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 14px var(--accent); }
+.brand:hover { text-decoration: none; }
+.topbar .spacer { flex: 1; }
+.topbar nav { display: flex; align-items: center; gap: 6px; }
+.topbar nav a { color: var(--text-dim); font-size: 14px; padding: 7px 11px; border-radius: 8px; }
+.topbar nav a:hover { color: var(--text); background: var(--bg-elev); text-decoration: none; }
+.lang-toggle { display: flex; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+.lang-toggle a { padding: 6px 11px; font-size: 13px; font-family: var(--mono); color: var(--text-dim); }
+.lang-toggle a.active { background: var(--accent); color: #04201d; font-weight: 600; }
+.lang-toggle a:hover { text-decoration: none; }
+.menu-btn { display: none; background: none; border: 1px solid var(--border); color: var(--text); border-radius: 8px; width: 38px; height: 38px; font-size: 18px; cursor: pointer; }
+
+/* -------------------------------------------------------------- layout --- */
+.shell { display: grid; grid-template-columns: var(--sidebar-w) minmax(0, 1fr); max-width: var(--maxw); margin: 0 auto; }
+
+aside.sidebar {
+    position: sticky; top: var(--header-h);
+    height: calc(100vh - var(--header-h));
+    overflow-y: auto;
+    padding: 28px 14px 60px 22px;
+    border-right: 1px solid var(--border-soft);
+}
+.sidebar h4 { font-family: var(--mono); font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-faint); margin: 22px 0 8px; }
+.sidebar h4:first-child { margin-top: 0; }
+.sidebar a { display: block; color: var(--text-dim); font-size: 14px; padding: 6px 12px; border-radius: 8px; border-left: 2px solid transparent; }
+.sidebar a:hover { color: var(--text); background: var(--bg-elev); text-decoration: none; }
+.sidebar a.active { color: var(--accent); border-left-color: var(--accent); background: linear-gradient(90deg, rgba(78,205,196,0.10), transparent); }
+
+main { padding: 40px clamp(22px, 5vw, 72px) 120px; min-width: 0; }
+.content { max-width: 820px; }
+
+/* --------------------------------------------------------------- hero --- */
+.hero { padding-top: calc(var(--header-h) + 18px); margin-bottom: 30px; }
+.eyebrow { font-family: var(--mono); font-size: 13px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent); margin-bottom: 16px; }
+.hero h1 { font-family: var(--display); font-weight: 800; font-size: clamp(40px, 7vw, 76px); line-height: 0.98; letter-spacing: -0.03em; margin-bottom: 18px; }
+.hero h1 .apple { background: linear-gradient(120deg, var(--accent), var(--violet)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+.hero .lede { font-size: clamp(17px, 2.3vw, 21px); color: var(--text-dim); max-width: 640px; }
+.hero-actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 28px; }
+
+.btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 20px; border-radius: 10px; font-weight: 600; font-size: 15px; border: 1px solid transparent; cursor: pointer; }
+.btn:hover { text-decoration: none; }
+.btn-primary { background: var(--accent); color: #042320; }
+.btn-primary:hover { background: #6fe0d8; transform: translateY(-1px); }
+.btn-ghost { border-color: var(--border); color: var(--text); }
+.btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+
+/* timeline motif — looks like a Perfetto track row set */
+.timeline { margin: 40px 0 8px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg-elev); padding: 16px 18px; overflow: hidden; }
+.tl-row { display: grid; grid-template-columns: 110px 1fr; align-items: center; gap: 12px; padding: 5px 0; }
+.tl-label { font-family: var(--mono); font-size: 11px; color: var(--text-faint); text-align: right; white-space: nowrap; }
+.tl-track { position: relative; height: 16px; }
+.tl-slice { position: absolute; height: 100%; border-radius: 4px; opacity: 0; animation: slice-in 0.5s ease forwards; }
+@keyframes slice-in { from { opacity: 0; transform: scaleX(0.4); transform-origin: left; } to { opacity: 0.92; transform: scaleX(1); } }
+
+/* --------------------------------------------------------- typography --- */
+.content section { padding-top: 14px; margin-bottom: 8px; }
+.content h2 { font-family: var(--display); font-weight: 700; font-size: clamp(27px, 4vw, 36px); letter-spacing: -0.02em; margin: 46px 0 14px; padding-bottom: 10px; border-bottom: 1px solid var(--border-soft); }
+.content h3 { font-family: var(--display); font-weight: 600; font-size: 21px; letter-spacing: -0.01em; margin: 30px 0 10px; color: var(--text); }
+.content h4 { font-size: 15px; font-weight: 600; margin: 20px 0 6px; color: var(--accent); font-family: var(--mono); }
+.content p { color: var(--text-dim); margin: 12px 0; }
+.content ul, .content ol { color: var(--text-dim); margin: 12px 0 12px 22px; }
+.content li { margin: 6px 0; }
+.content strong { color: var(--text); font-weight: 600; }
+.content em { color: var(--text); font-style: normal; border-bottom: 1px dotted var(--text-faint); }
+
+code { font-family: var(--mono); font-size: 0.88em; background: var(--bg-elev-2, #1a232c); color: var(--accent); padding: 2px 6px; border-radius: 5px; border: 1px solid var(--border-soft); }
+
+/* code blocks */
+.code { position: relative; margin: 16px 0; border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg-code); overflow: hidden; }
+.code-head { display: flex; align-items: center; gap: 8px; padding: 8px 14px; border-bottom: 1px solid var(--border-soft); background: rgba(255,255,255,0.015); }
+.code-head .lang { font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-faint); }
+.code-head .copy { margin-left: auto; background: none; border: 1px solid var(--border); color: var(--text-dim); font-family: var(--mono); font-size: 11px; padding: 3px 9px; border-radius: 6px; cursor: pointer; }
+.code-head .copy:hover { color: var(--accent); border-color: var(--accent); }
+.code pre { margin: 0; padding: 16px 18px; overflow-x: auto; }
+.code code { background: none; border: none; color: #cdd9e5; padding: 0; font-size: 13.5px; line-height: 1.7; }
+.code .k { color: var(--violet); }     /* keyword */
+.code .s { color: var(--accent); }     /* string */
+.code .c { color: var(--text-faint); font-style: italic; } /* comment */
+.code .f { color: var(--amber); }      /* function / api */
+.code .n { color: var(--coral); }      /* number / attr */
+
+/* callouts */
+.callout { display: flex; gap: 12px; margin: 18px 0; padding: 14px 16px; border-radius: var(--radius); border: 1px solid var(--border); background: var(--bg-elev); }
+.callout .ic { font-size: 18px; line-height: 1.5; }
+.callout p { margin: 0; color: var(--text-dim); }
+.callout.tip { border-left: 3px solid var(--accent); }
+.callout.warn { border-left: 3px solid var(--amber); }
+.callout.danger { border-left: 3px solid var(--coral); }
+
+/* feature / route cards */
+.grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; margin: 20px 0; }
+.card { border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg-elev); padding: 20px; }
+.card h3 { margin-top: 0; }
+.card .tag { display: inline-block; font-family: var(--mono); font-size: 11px; padding: 2px 8px; border-radius: 20px; margin-bottom: 10px; }
+.tag.everywhere { color: var(--accent); border: 1px solid var(--accent-deep); }
+.tag.sim { color: var(--amber); border: 1px solid #6b5a1f; }
+.tag.arm { color: var(--violet); border: 1px solid #4b3b78; }
+
+/* tables */
+table { width: 100%; border-collapse: collapse; margin: 18px 0; font-size: 14px; }
+th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--border-soft); }
+th { font-family: var(--mono); font-size: 12px; letter-spacing: 0.04em; text-transform: uppercase; color: var(--text-faint); }
+td { color: var(--text-dim); }
+td code { font-size: 12.5px; }
+
+/* step list */
+.steps { list-style: none; margin-left: 0; counter-reset: step; }
+.steps > li { position: relative; padding-left: 44px; margin: 16px 0; }
+.steps > li::before { counter-increment: step; content: counter(step); position: absolute; left: 0; top: 0; width: 28px; height: 28px; display: grid; place-items: center; border-radius: 50%; background: var(--bg-elev); border: 1px solid var(--accent-deep); color: var(--accent); font-family: var(--mono); font-size: 13px; font-weight: 600; }
+
+footer { border-top: 1px solid var(--border-soft); margin-top: 60px; padding: 30px clamp(22px,5vw,72px); color: var(--text-faint); font-size: 13px; }
+footer a { color: var(--text-dim); }
+
+.zh-note { font-family: var(--mono); font-size: 12.5px; color: var(--text-faint); background: var(--bg-elev); border: 1px dashed var(--border); border-radius: 8px; padding: 10px 14px; margin: 16px 0; }
+
+/* --------------------------------------------------------- responsive --- */
+@media (max-width: 900px) {
+    .shell { grid-template-columns: 1fr; }
+    aside.sidebar {
+        position: fixed; top: var(--header-h); left: 0; bottom: 0; width: 80%; max-width: 320px;
+        background: var(--bg); z-index: 90; border-right: 1px solid var(--border);
+        transform: translateX(-105%); transition: transform 0.25s ease;
+    }
+    aside.sidebar.open { transform: translateX(0); }
+    .menu-btn { display: grid; place-items: center; }
+    .topbar nav .hide-sm { display: none; }
+    .scrim { position: fixed; inset: var(--header-h) 0 0 0; background: rgba(0,0,0,0.5); z-index: 85; opacity: 0; pointer-events: none; transition: opacity 0.2s; }
+    .scrim.show { opacity: 1; pointer-events: auto; }
+}

--- a/Tutorial/zh.html
+++ b/Tutorial/zh.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>AppleTrace — 教程与使用指南</title>
+<meta name="description" content="AppleTrace 完整指南：为 Objective-C、C/C++、Swift 埋点，并在 Perfetto 中查看时间线。">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+<header class="topbar">
+    <a class="brand" href="zh.html"><span class="dot"></span>AppleTrace</a>
+    <button class="menu-btn" aria-label="菜单">☰</button>
+    <div class="spacer"></div>
+    <nav>
+        <a class="hide-sm" href="#quick-start">快速开始</a>
+        <a class="hide-sm" href="https://github.com/everettjf/AppleTrace" target="_blank" rel="noopener">GitHub ↗</a>
+        <span class="lang-toggle"><a href="index.html">EN</a><a class="active" href="zh.html">中文</a></span>
+    </nav>
+</header>
+
+<div class="scrim"></div>
+
+<div class="shell">
+    <aside class="sidebar">
+        <h4>开始</h4>
+        <a href="#introduction">简介</a>
+        <a href="#quick-start">快速开始</a>
+        <a href="#installation">安装</a>
+        <h4>教程</h4>
+        <a href="#manual">手动埋点</a>
+        <a href="#swift">追踪 Swift</a>
+        <a href="#objc-hook">objc_msgSend Hook</a>
+        <a href="#events">事件类型</a>
+        <h4>工作流</h4>
+        <a href="#visualize">在 Perfetto 查看</a>
+        <a href="#demos">示例 App</a>
+        <h4>参考</h4>
+        <a href="#env">环境变量</a>
+        <a href="#platforms">平台支持</a>
+        <a href="#faq">FAQ 与排查</a>
+    </aside>
+
+    <main>
+        <div class="content">
+
+        <div class="hero">
+            <div class="eyebrow">iOS / macOS 追踪 → Perfetto</div>
+            <h1>《<span class="apple">AppleTrace</span>》使用手册</h1>
+            <p class="lede">一个轻量、可嵌入的 tracer：记录 App 的执行时间线——手动 section、Swift 宏、或每一次 <code>objc_msgSend</code>——并直接在浏览器里用 <a href="https://ui.perfetto.dev" target="_blank" rel="noopener">Perfetto</a> 呈现。</p>
+            <div class="hero-actions">
+                <a class="btn btn-primary" href="#quick-start">5 分钟上手 →</a>
+                <a class="btn btn-ghost" href="https://github.com/everettjf/AppleTrace" target="_blank" rel="noopener">前往 GitHub</a>
+            </div>
+
+            <div class="timeline" aria-hidden="true">
+                <div class="tl-row"><span class="tl-label">Main Thread</span><span class="tl-track">
+                    <span class="tl-slice" style="left:0;width:24%;background:var(--accent);animation-delay:.05s"></span>
+                    <span class="tl-slice" style="left:26%;width:40%;background:var(--accent);animation-delay:.15s"></span>
+                    <span class="tl-slice" style="left:68%;width:30%;background:var(--accent);animation-delay:.25s"></span>
+                </span></div>
+                <div class="tl-row"><span class="tl-label">RenderLoop</span><span class="tl-track">
+                    <span class="tl-slice" style="left:8%;width:14%;background:var(--violet);animation-delay:.3s"></span>
+                    <span class="tl-slice" style="left:24%;width:14%;background:var(--violet);animation-delay:.4s"></span>
+                    <span class="tl-slice" style="left:40%;width:14%;background:var(--violet);animation-delay:.5s"></span>
+                    <span class="tl-slice" style="left:56%;width:14%;background:var(--violet);animation-delay:.6s"></span>
+                </span></div>
+                <div class="tl-row"><span class="tl-label">NetworkClient</span><span class="tl-track">
+                    <span class="tl-slice" style="left:30%;width:52%;background:var(--coral);animation-delay:.45s"></span>
+                </span></div>
+                <div class="tl-row"><span class="tl-label">FPS</span><span class="tl-track">
+                    <span class="tl-slice" style="left:0;width:100%;background:linear-gradient(90deg,var(--amber),transparent);height:8px;top:4px;animation-delay:.7s"></span>
+                </span></div>
+            </div>
+        </div>
+
+        <section id="introduction">
+            <h2>简介</h2>
+            <p>AppleTrace 给你的 App 埋点——加 marker、标注 Swift 函数、或 hook 消息发送——把事件时间线写进沙盒里的 <em>trace 片段</em>。一套小的 Python 流水线把这些片段合并成一个 <code>trace.json</code>，直接在 Perfetto 里打开，查看调用时间线、耗时、线程与计数器。</p>
+            <p>产生事件有三种方式，按需选用，它们都落进同一条 trace：</p>
+            <div class="grid2">
+                <div class="card">
+                    <span class="tag everywhere">全平台</span>
+                    <h3>手动 section</h3>
+                    <p>用 <code>APTBeginSection</code>/<code>APTEndSection</code>（或 Swift 宏）包住代码。风险最低，精确控制要计时的范围。</p>
+                </div>
+                <div class="card">
+                    <span class="tag arm">arm64</span>
+                    <h3>objc_msgSend hook</h3>
+                    <p>用 fishhook 式符号重绑自动追踪每一次 OC 消息发送。零改动，仅限 Objective-C。</p>
+                </div>
+                <div class="card">
+                    <span class="tag sim">模拟器 / macOS</span>
+                    <h3>Swift 自动 hook</h3>
+                    <p>可选的 <code>AppleTraceAuto</code> 桥接 SwiftTrace，零标注追踪 Swift 类层级。</p>
+                </div>
+            </div>
+        </section>
+
+        <section id="quick-start">
+            <h2>快速开始</h2>
+            <p>最快看到 trace 的方式是内置的示例 App——无需自己写埋点。</p>
+            <ol class="steps">
+                <li><strong>克隆并打开示例。</strong>
+                    <div class="code"><div class="code-head"><span class="lang">bash</span><button class="copy">复制</button></div><pre><code>git clone https://github.com/everettjf/AppleTrace.git
+cd AppleTrace
+open sample/AppleTraceSwiftDemo/AppleTraceSwiftDemo.xcodeproj</code></pre></div>
+                </li>
+                <li><strong>运行</strong>（模拟器或真机），点击 <strong>Generate Trace</strong>。App 会跑一段多线程负载，并显示磁盘上的 <em>trace 目录</em>。</li>
+                <li><strong>在 Mac 上合并片段</strong>：
+                    <div class="code"><div class="code-head"><span class="lang">bash</span><button class="copy">复制</button></div><pre><code>python3 merge.py -d "&lt;App 中显示的 trace 目录&gt;"
+# → 在片段旁生成 trace.json</code></pre></div>
+                </li>
+                <li><strong>在 Perfetto 打开。</strong>进入 <a href="https://ui.perfetto.dev" target="_blank" rel="noopener">ui.perfetto.dev</a>，把 <code>trace.json</code> 拖进去即可。</li>
+            </ol>
+            <div class="callout tip"><span class="ic">💡</span><p>想更快？<code>sh go.sh "&lt;trace 目录&gt;"</code> 一步完成合并并打开 Perfetto。</p></div>
+        </section>
+
+        <section id="installation">
+            <h2>安装</h2>
+            <h3>环境要求</h3>
+            <ul>
+                <li>Xcode、Python 3、浏览器（Perfetto 在 <a href="https://ui.perfetto.dev" target="_blank" rel="noopener">ui.perfetto.dev</a>）。</li>
+                <li><code>ldid</code> 仅在重签 loader 时需要；<code>pytest</code> 仅跑测试时需要。</li>
+            </ul>
+
+            <h3>Swift Package（Swift 项目，也是新项目最干净的方式）</h3>
+            <div class="code"><div class="code-head"><span class="lang">swift — Package.swift</span><button class="copy">复制</button></div><pre><code>dependencies: [
+    .package(url: "https://github.com/everettjf/AppleTrace.git", branch: "master"),
+],
+targets: [
+    .target(name: "MyApp", dependencies: [
+        .product(name: "AppleTrace", package: "AppleTrace"),
+        // 可选，仅限模拟器/macOS：
+        .product(name: "AppleTraceAuto", package: "AppleTrace"),
+    ]),
+]</code></pre></div>
+
+            <h3>嵌入 framework（Objective-C / C / C++）</h3>
+            <p>打开 <code>appletrace/appletrace.xcodeproj</code> 构建 framework，把 <code>appletrace.framework</code> 嵌入你的 target。可参考 <code>sample/ManualSectionDemo</code>。</p>
+        </section>
+
+        <section id="manual">
+            <h2>教程 · 手动埋点</h2>
+            <p>手动 section 是推荐的基线——适配所有 iOS/macOS 版本，产出命名清晰的切片。</p>
+            <h3>Objective-C</h3>
+            <div class="code"><div class="code-head"><span class="lang">objective-c</span><button class="copy">复制</button></div><pre><code>#import &lt;appletrace/appletrace.h&gt;
+
+- (void)viewDidLoad {
+    APTBegin;                       // 自动命名为 "[类名 viewDidLoad]"
+    [super viewDidLoad];
+    APTEnd;
+}
+
+- (void)loadFeed {
+    APTBeginSection("network");     // 自定义 section 名
+    // ... 工作 ...
+    APTEndSection("network");
+}</code></pre></div>
+            <p><code>APTBegin</code>/<code>APTEnd</code> 用类名+方法名自动命名；要自定义就用 <code>APTBeginSection</code>/<code>APTEndSection</code>。同线程内按 LIFO 嵌套。</p>
+            <h3>C / C++</h3>
+            <div class="code"><div class="code-head"><span class="lang">cpp</span><button class="copy">复制</button></div><pre><code>#include &lt;appletrace/appletrace.h&gt;
+
+void safer() {
+    APTScopeSection("decode");      // RAII：作用域结束自动 end
+    // ... 工作 ...
+}</code></pre></div>
+            <div class="callout warn"><span class="ic">⚠️</span><p>事件按线程缓冲，在达到阈值、调用 <code>APTFlush()</code>、或线程退出时落盘。读取 trace 前<strong>务必调用 <code>APTFlush()</code></strong>（比如进入后台时），否则短小的运行可能看起来是空的。</p></div>
+        </section>
+
+        <section id="swift">
+            <h2>教程 · 追踪 Swift</h2>
+            <p><code>objc_msgSend</code> hook 看不到 Swift 的静态 / vtable / witness 派发，所以 Swift 走<strong>源码级埋点</strong>。加入 Swift 包后 <code>import AppleTrace</code>。</p>
+            <h3>作用域 span 与宏</h3>
+            <div class="code"><div class="code-head"><span class="lang">swift</span><button class="copy">复制</button></div><pre><code>import AppleTrace
+
+// 作用域 span——即使 throw / 提前返回也会闭合：
+withSpan("loadFeed") { try? loadFeed() }
+
+// 标注函数。section 以 #function 命名，对 final 类、struct、protocol
+// 方法都生效——begin/end 在编译期插入函数体，绕开了派发问题。
+@Traced
+func decodeImage() { /* ... */ }
+
+// @TraceAll 给每个有函数体的方法都加上 @Traced：
+@TraceAll
+final class FeedViewModel {
+    func reload() { /* 已追踪 */ }
+    func render() { /* 已追踪 */ }
+}
+
+APTFlush()   // 或 AppleTrace.flush()</code></pre></div>
+            <h3>零标注自动追踪</h3>
+            <p>可选的 <code>AppleTraceAuto</code> 桥接 <a href="https://github.com/johnno1962/SwiftTrace" target="_blank" rel="noopener">SwiftTrace</a>，无需标注即可 hook 类层级：</p>
+            <div class="code"><div class="code-head"><span class="lang">swift</span><button class="copy">复制</button></div><pre><code>import AppleTraceAuto
+
+#if targetEnvironment(simulator)
+AppleTraceAuto.trace(aClass: FeedViewModel.self)   // 进入/退出 → AppleTrace
+#endif</code></pre></div>
+            <div class="callout danger"><span class="ic">🚫</span><p><strong><code>AppleTraceAuto</code> 仅限模拟器 / macOS。</strong>SwiftTrace 改写经过指针认证的 vtable 槽，真机上不安全——务必用 <code>#if targetEnvironment(simulator)</code> 包起来。它也看不到 <code>final</code> / 静态派发的方法。宏没有这些限制，是真机上的首选。</p></div>
+        </section>
+
+        <section id="objc-hook">
+            <h2>教程 · 自动 objc_msgSend Hook</h2>
+            <p>Objective-C app 可以无埋点追踪<em>每一次</em>消息发送。该 hook 是 arm64 上 fishhook 式的符号重绑，启动后安装一次：</p>
+            <div class="code"><div class="code-head"><span class="lang">objective-c</span><button class="copy">复制</button></div><pre><code>// 例如在 application:didFinishLaunchingWithOptions: 早期
+if (APTInstallObjcMsgSendHook()) {
+    NSLog(@"AppleTrace: objc_msgSend hook 已安装");
+}</code></pre></div>
+            <p>每次被追踪的发送会变成 <code>[类]方法</code> 的 begin/end 对。完整示例见 <code>sample/TraceAllMsgDemo</code>，其中验证了浮点参数、结构体返回与 <code>super</code> 派发的处理。</p>
+            <div class="callout warn"><span class="ic">⚠️</span><p><strong>仅限 arm64。</strong>该 hook 在 arm64e 上会硬报错（调用方通过认证的 GOT 入口到达 <code>objc_msgSend</code>）。请构建纯 arm64 切片。</p></div>
+        </section>
+
+        <section id="events">
+            <h2>教程 · 事件类型</h2>
+            <p>除了 section，AppleTrace 还记录 Perfetto 能绘制的事件种类：</p>
+            <div class="code"><div class="code-head"><span class="lang">objective-c</span><button class="copy">复制</button></div><pre><code>// 在当前线程时间线上打一个点
+APTInstant("cache_miss");
+
+// 随时间变化的数值 → counter 曲线（内存、FPS、队列深度…）
+APTCounter("resident_mb", 142.5);
+
+// 跨线程/队列的工作，按 (name, id) 匹配 → 异步弧
+uint64_t reqID = 42;
+APTAsyncBegin("image_load", reqID);
+dispatch_async(queue, ^{
+    APTAsyncEnd("image_load", reqID);
+});</code></pre></div>
+            <table>
+                <tr><th>事件</th><th>API</th><th>Perfetto 呈现</th></tr>
+                <tr><td>Section</td><td><code>APTBeginSection</code> / <code>APTEndSection</code></td><td>线程轨道上的嵌套切片</td></tr>
+                <tr><td>Instant</td><td><code>APTInstant</code></td><td>时间点 marker</td></tr>
+                <tr><td>Counter</td><td><code>APTCounter</code></td><td>曲线轨道</td></tr>
+                <tr><td>Async</td><td><code>APTAsyncBegin</code> / <code>APTAsyncEnd</code></td><td>可跨线程的弧</td></tr>
+            </table>
+            <p>Swift 封装一一对应：<code>traceInstant</code>、<code>traceCounter</code>、<code>asyncBegin</code>、<code>asyncEnd</code>。</p>
+        </section>
+
+        <section id="visualize">
+            <h2>在 Perfetto 查看</h2>
+            <h3>1 · 拉取 trace 片段</h3>
+            <p>片段写在 <code>&lt;app 沙盒&gt;/Library/appletracedata</code>。</p>
+            <ul>
+                <li><strong>模拟器：</strong>目录就在 Mac 本地，示例 App 会显示路径。</li>
+                <li><strong>真机：</strong>Xcode ▸ <em>Window ▸ Devices and Simulators ▸ Download Container</em>，或 <code>xcrun devicectl device copy from … --domain-type appDataContainer --source Library/appletracedata --destination ./trace</code>。</li>
+            </ul>
+            <h3>2 · 合并</h3>
+            <div class="code"><div class="code-head"><span class="lang">bash</span><button class="copy">复制</button></div><pre><code>python3 merge.py -d /path/to/appletracedata     # → trace.json
+# 或统一 CLI：
+python3 scripts/appletrace_cli.py open /path/to/appletracedata
+# 或合并并打开 Perfetto：
+sh go.sh /path/to/appletracedata</code></pre></div>
+            <h3>3 · 浏览</h3>
+            <p>把 <code>trace.json</code> 拖进 <a href="https://ui.perfetto.dev" target="_blank" rel="noopener">ui.perfetto.dev</a>。用 <kbd>W</kbd>/<kbd>S</kbd> 缩放、<kbd>A</kbd>/<kbd>D</kbd> 平移，搜索框可跳转到切片。</p>
+            <h3>二进制片段（可选，更小更快）</h3>
+            <p>设置 <code>APPLETRACE_BINARY=1</code> 改写紧凑的二进制片段格式。<code>merge.py</code> 对两种格式都透明解码——工作流不变。</p>
+        </section>
+
+        <section id="demos">
+            <h2>示例 App</h2>
+            <table>
+                <tr><th>示例</th><th>语言</th><th>演示</th></tr>
+                <tr><td><code>sample/ManualSectionDemo</code></td><td>Objective-C</td><td>手动 section、counter、async、多线程</td></tr>
+                <tr><td><code>sample/AppleTraceSwiftDemo</code></td><td>Swift</td><td><code>@Traced</code>/<code>@TraceAll</code>/<code>withSpan</code> + <code>AppleTraceAuto</code> hook</td></tr>
+                <tr><td><code>sample/TraceAllMsgDemo</code></td><td>Objective-C</td><td>自动 <code>objc_msgSend</code> hook</td></tr>
+            </table>
+            <p>每个引导式 App 都有 <strong>Generate Trace</strong> 按钮，显示 trace 目录并打印合并/Perfetto 命令。Swift demo 依赖本地包，请从仓库内打开，让 Xcode 自动解析 product。</p>
+        </section>
+
+        <section id="env">
+            <h2>环境变量</h2>
+            <table>
+                <tr><th>变量</th><th>默认</th><th>作用</th></tr>
+                <tr><td><code>APPLETRACE_ENABLED</code></td><td><code>true</code></td><td>录制总开关。</td></tr>
+                <tr><td><code>APPLETRACE_BINARY</code></td><td><code>false</code></td><td>写二进制片段而非文本。</td></tr>
+                <tr><td><code>APPLETRACE_DATA_DIR</code></td><td><em>沙盒</em></td><td>覆盖片段写入目录。</td></tr>
+                <tr><td><code>APPLETRACE_BLOCK_SIZE_MB</code></td><td><code>16</code></td><td>每个片段的 mmap 块大小（1–256 MB）。</td></tr>
+                <tr><td><code>APPLETRACE_KEEP_EXISTING</code></td><td><code>false</code></td><td>保留旧 trace 目录而非覆盖。</td></tr>
+            </table>
+            <p>代码内也有运行时控制：<code>APTSetEnabled(BOOL)</code>、<code>APTIsEnabled()</code>、<code>APTGetTraceDirectory()</code>、<code>APTFlush()</code>、<code>APTSyncWait()</code>。</p>
+        </section>
+
+        <section id="platforms">
+            <h2>平台支持</h2>
+            <table>
+                <tr><th>模式</th><th>适用范围</th></tr>
+                <tr><td>手动 section 与事件</td><td>所有 iOS/macOS 版本，全语言</td></tr>
+                <tr><td>Swift 宏（<code>@Traced</code>/<code>@TraceAll</code>/<code>withSpan</code>）</td><td>模拟器<strong>与真机</strong></td></tr>
+                <tr><td><code>objc_msgSend</code> hook</td><td>arm64（非 arm64e）</td></tr>
+                <tr><td><code>AppleTraceAuto</code>（SwiftTrace）</td><td>仅模拟器 / macOS</td></tr>
+            </table>
+            <h3>为什么 Swift 需要源码级追踪</h3>
+            <p>Swift 为性能绕开消息派发：<code>struct</code>/<code>final</code> 方法与全模块优化的调用走<em>静态</em>派发；类方法走 <em>vtable</em>；protocol 方法走 <em>witness table</em>。它们都不经过 <code>objc_msgSend</code>，所以自动 hook 只能看到很薄的 <code>@objc dynamic</code> 表面。宏直接在源码插桩，因此覆盖全部四种派发。</p>
+        </section>
+
+        <section id="faq">
+            <h2>FAQ 与排查</h2>
+            <h4>trace 是空的 / 只有元数据</h4>
+            <p>writer 按线程批量缓冲。读取前调用 <code>APTFlush()</code>（如进入后台、或场景结束时）。示例 App 已替你 flush。</p>
+            <h4>构建报错：<code>SDK does not contain 'libarclite'</code></h4>
+            <p>部署目标过旧。把 <code>IPHONEOS_DEPLOYMENT_TARGET</code> 设为 12.0 或更高——新版 Xcode 移除了 pre-12 的 ARC 兼容库。</p>
+            <h4>Swift app 启动崩溃 <code>Library not loaded: @rpath/SwiftTrace.framework</code></h4>
+            <p>app target 需要 <code>LD_RUNPATH_SEARCH_PATHS = @executable_path/Frameworks</code>，dyld 才能在真机上找到内嵌的动态 framework。</p>
+            <h4><code>AppleTraceAuto</code> 某些方法追踪不到</h4>
+            <p>SwiftTrace 无法 hook <code>final</code> / 静态派发的方法，且仅限模拟器/macOS。这类请用 <code>@Traced</code>/<code>@TraceAll</code> 宏。</p>
+            <h4>命令行 <code>xcodebuild</code> 找不到宏插件的 SwiftSyntax</h4>
+            <p>去掉 <code>-sdk iphonesimulator</code>，只用 <code>-destination</code>；<code>-sdk</code> 会把 host 宏插件错误地按目标 SDK 编译。</p>
+        </section>
+
+        </div>
+        <footer>
+            <p>AppleTrace 采用 MIT 协议；可视化仅用 <a href="https://ui.perfetto.dev" target="_blank" rel="noopener">Perfetto</a>。 ·
+            <a href="https://github.com/everettjf/AppleTrace" target="_blank" rel="noopener">github.com/everettjf/AppleTrace</a> ·
+            <a href="index.html">English</a></p>
+        </footer>
+    </main>
+</div>
+
+<script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## What

A static, **no-build** GitHub Pages site under `Tutorial/` — a comprehensive usage guide for AppleTrace, **English primary** (`index.html`) and **Chinese secondary** (`zh.html`) with an EN/中文 toggle.

Covered end to end: Introduction · Quick Start · Installation (SwiftPM + framework) · Manual instrumentation (ObjC/C/C++) · Tracing Swift (macros + `AppleTraceAuto`) · `objc_msgSend` hook · Event types · Visualizing in Perfetto · Demo apps · Environment variables · Platform support · FAQ/troubleshooting.

## Design

A dark **trace-viewer** theme that echoes a Perfetto timeline — teal brand accent (`#4ECDC4`), an animated track-lane hero motif, distinctive type (Bricolage Grotesque + IBM Plex Sans/Mono), sticky sidebar nav with scroll-spy, copy-to-clipboard on code blocks, and a mobile menu. Plain HTML/CSS + progressive-enhancement JS; `.nojekyll` so Pages serves it verbatim.

## Deploy

`.github/workflows/pages.yml` publishes `Tutorial/` to Pages on pushes to `master`.

⚠️ **One-time setup required:** repo **Settings ▸ Pages ▸ Build and deployment ▸ Source = "GitHub Actions"**. After that, merging this (or any later `Tutorial/**` change) deploys to `https://everettjf.github.io/AppleTrace/`. README / README_CN already link there.

## Verification

- Both pages structurally validated (balanced markup) and rendered with headless Chrome (EN + 中文) — see the trace-lane hero, sidebar, cards, code blocks, and CJK text all display correctly.
- No build step, no runtime deps; the content matches the current code (env vars, APIs, the Swift on-device caveats, the `libarclite` / rpath / `-sdk` gotchas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)